### PR TITLE
Recommend clients to build before running the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ The program doesn't require installation or deployment, so it's just enough to
 run it directly via `gradlew` since it's meant to be a script rather than an
 app.
 
+### Preferred Deployment Approach
+
+For a more formal execution of the Kotlin script, build the distribution 
+with Gradle and run the binary from the `build` directory.
+
+- `./gradlew installDist`
+- `cd build/install/dorep-for-jekyll/bin`
+- `./dorep-for-jekyll build {src} {dst}`
+
 ### Testing Settings
 
 For testing the app, use the dirs [test/src](test/src) and [test/dst](test/dst).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,3 +41,13 @@ tasks.withType<KotlinCompile> {
         jvmTarget.set(JvmTarget.JVM_21)
     }
 }
+
+distributions {
+    main {
+        contents {
+            from("$rootDir/jekyll") {
+                into("jekyll")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/software/math/tsd/jekyll/System.kt
+++ b/src/main/kotlin/software/math/tsd/jekyll/System.kt
@@ -17,7 +17,23 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.*
 import java.util.stream.Stream
+import kotlin.io.path.Path
+import kotlin.io.path.absolute
 import kotlin.io.path.name
+
+enum class AppInstallation {
+    Dev,
+    Prod,
+}
+
+fun getRootAbsPath() = Path("").absolute()
+
+fun resolveAppInstallation(): AppInstallation {
+    val rootPath = getRootAbsPath()
+
+    return if (rootPath.name == "bin") AppInstallation.Prod
+    else AppInstallation.Dev
+}
 
 fun copyDirectory(
     sourceDir: Path,

--- a/src/main/kotlin/software/math/tsd/jekyll/jekyll/Jekyll.kt
+++ b/src/main/kotlin/software/math/tsd/jekyll/jekyll/Jekyll.kt
@@ -6,17 +6,17 @@ package software.math.tsd.jekyll.jekyll
 
 import arrow.core.Either
 import arrow.core.left
-import software.math.tsd.jekyll.copyDirectory
-import software.math.tsd.jekyll.runCommand
+import software.math.tsd.jekyll.*
 import java.io.IOException
 import java.nio.file.Path
-import kotlin.io.path.Path
 
 data class JekyllOutput(val dst: Path)
 
 fun JekyllOutput.copyJekyllRootFiles(): Either<String, Unit> = try {
+    val jekyllPath = resolveJekyllDirectory()
+
     copyDirectory(
-        Path("jekyll"),
+        jekyllPath,
         dst,
     )
 }
@@ -42,3 +42,11 @@ fun JekyllOutput.jekyllBuild(): Either<String, String> = runCommand(
     "bundle exec jekyll build",
     dst
 )
+
+private fun resolveJekyllDirectory() = when (resolveAppInstallation()) {
+    // Root project
+    AppInstallation.Dev  -> getRootAbsPath().resolve("jekyll")
+
+    // dorep-for-jekyll/bin, files are in dorep-for-jekyll/jekyll
+    AppInstallation.Prod -> getRootAbsPath().parent.resolve("jekyll")
+}


### PR DESCRIPTION
The client (Texsydo Web MVP) should implement a more serious way of running the script since it's a Kotlin app in the end, so it needs building and some installation.

The recommended execution approach is to build via `gradle installDist` and execute the binary from the `build/install` directory.

The building will copy the Jekyll website resources to the installation directory. That way, client users can run the script from the binary to set up a more professional or production experience.