### PR TITLE
Add environment param to runCommand

### DIFF
--- a/src/main/kotlin/software/math/tsd/jekyll/System.kt
+++ b/src/main/kotlin/software/math/tsd/jekyll/System.kt
@@ -91,6 +91,7 @@ fun deleteDirectoryRecursively(dir: Path) {
 fun runCommand(
     command: String,
     workingDir: Path? = null,
+    env: Map<String, String> = emptyMap(),
 ): Either<String, String> {
     val processBuilder = getProcessBuilder(command)
 
@@ -98,6 +99,7 @@ fun runCommand(
 
     if (workingDir != null) {
         processBuilder.directory(workingDir.toFile())
+        processBuilder.environment().putAll(env)
     }
 
     return try {


### PR DESCRIPTION
Some commands need shell environment variables to find scripts or paths (e.g., `jekyll` path).