### PR TITLE
Drop cmd bundle and set Jekyll env vars 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ with Gradle and run the binary from the `build` directory.
 
 For testing the app, use the dirs [test/src](test/src) and [test/dst](test/dst).
 
-Usage: `gradlew run --args="build test/src test/dst"`.
+Usage: `./gradlew run --args="build test/src test/dst"`.
 
 ## Contact
 

--- a/jekyll/_layouts/default.html
+++ b/jekyll/_layouts/default.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% seo %}
-    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: relative_url }}">
     {% include head-custom.html %}
 
     {% assign ga = site.data.site_meta.google_analytics %}

--- a/src/main/kotlin/software/math/tsd/jekyll/jekyll/Jekyll.kt
+++ b/src/main/kotlin/software/math/tsd/jekyll/jekyll/Jekyll.kt
@@ -39,8 +39,9 @@ catch (e: IOException) {
 }
 
 fun JekyllOutput.jekyllBuild(): Either<String, String> = runCommand(
-    "bundle exec jekyll build",
-    dst
+    "jekyll build",
+    dst,
+    getEnvVars(),
 )
 
 private fun resolveJekyllDirectory() = when (resolveAppInstallation()) {
@@ -49,4 +50,14 @@ private fun resolveJekyllDirectory() = when (resolveAppInstallation()) {
 
     // dorep-for-jekyll/bin, files are in dorep-for-jekyll/jekyll
     AppInstallation.Prod -> getRootAbsPath().parent.resolve("jekyll")
+}
+
+private fun getEnvVars(): Map<String, String> {
+    val userHome = System.getProperty("user.home")
+
+    return mapOf(
+        "PATH" to "$userHome/gems/bin:${System.getenv("PATH")}",
+        "GEM_HOME" to "$userHome/gems",
+        "PAGES_REPO_NWO" to "texsydo/dorep-for-jekyll"
+    )
 }


### PR DESCRIPTION
The program doesn't find the `bundle` or `jekyll` binaries when running from Kotlin, so it needs their paths to call them. Further, it doesn't find `gems` when running `bundle` even after passing the environment paths, so removing it and calling `jekyll` directly simplifies and fixes the execution. Third, Jekyll will fail to build out of a Git repository because of a GitHub Pages plugin, which is why the `PAGES_REPO_NWO` variable is set with a dummy value.